### PR TITLE
Create a standardized training parser

### DIFF
--- a/src/deepdisc/utils/parse_arguments.py
+++ b/src/deepdisc/utils/parse_arguments.py
@@ -1,0 +1,152 @@
+import argparse
+import os
+import sys
+
+
+def make_training_arg_parser(epilog=None):
+    """Create the parser for DeepDisc, including common arguments used by
+    detectron2 users.
+
+    Parameters
+    ----------
+    epilog: str
+        The epilog passed to ArgumentParser describing the usage.
+
+    Returns
+    -------
+    parser : ArgumentParser
+        The argument parser.
+    """
+    # Create the initial parser.
+    parser = argparse.ArgumentParser(
+        epilog=epilog
+        or f"""
+Examples:
+Run on single machine:
+    $ {sys.argv[0]} --num-gpus 8 --config-file cfg.yaml
+Change some config options:
+    $ {sys.argv[0]} --config-file cfg.yaml MODEL.WEIGHTS /path/to/weight.pth SOLVER.BASE_LR 0.001
+Run on multiple machines:
+    (machine0)$ {sys.argv[0]} --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
+    (machine1)$ {sys.argv[0]} --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # Add arguments for the run.
+    run_args = parser.add_argument_group("Basic run arguments")
+    run_args.add_argument(
+        "--cfgfile",
+        type=str,
+        default="COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml",
+        help="path to model config file",
+    )
+    run_args.add_argument(
+        "--config-file", default="", metavar="FILE", help="path to config file"
+    )
+    run_args.add_argument(
+        "--data-dir",
+        type=str,
+        default="/home/shared/hsc/HSC/HSC_DR3/data/",
+        help="directory with data",
+    )
+
+    run_args.add_argument(
+        "--eval-only", action="store_true", help="perform evaluation only"
+    )
+    run_args.add_argument(
+        "--from-scratch",
+        action="store_true",
+        help="use this if you don't want to use pretrained weights",
+    )
+    run_args.add_argument(
+        "--output-dir", type=str, default="./", help="output directory to save model"
+    )
+    run_args.add_argument(
+        "--resume",
+        action="store_true",
+        help="Whether to attempt to resume from the checkpoint directory. "
+        "See documentation of `DefaultTrainer.resume_or_load()` for what it means.",
+    )
+    run_args.add_argument(
+        "--run-name", type=str, default="Swin_test", help="output name for run"
+    )
+
+    # Add arguments for the machine specifications
+    machine_args = parser.add_argument_group("Machine arguments")
+    machine_args.add_argument(
+        "--num-gpus", type=int, default=1, help="number of gpus *per machine*"
+    )
+    machine_args.add_argument(
+        "--num-machines", type=int, default=1, help="total number of machines"
+    )
+    machine_args.add_argument(
+        "--machine-rank",
+        type=int,
+        default=0,
+        help="the rank of this machine (unique per machine)",
+    )
+
+    # Add arguments for the data normalization and modeling.
+    model_args = parser.add_argument_group("Model configuration arguments")
+    model_args.add_argument(
+        "--A", type=float, default=1e3, help="scaling factor for int16"
+    )
+    model_args.add_argument(
+        "--alphas", type=float, nargs="*", help="weights for focal loss"
+    )
+    model_args.add_argument(
+        "--cp",
+        type=float,
+        default=99.99,
+        help="ceiling percentile for saturation cutoff",
+    )
+    model_args.add_argument("--do-fl", action="store_true", help="use focal loss")
+    model_args.add_argument(
+        "--do-norm",
+        action="store_true",
+        help="normalize input image (ignore if lupton)",
+    )
+    model_args.add_argument("--dtype", type=int, default=8, help="data type of array")
+    model_args.add_argument("--modname", type=str, default="swin", help="")
+    model_args.add_argument(
+        "--norm", type=str, default="astrolupton", help="contrast scaling"
+    )
+    model_args.add_argument("--Q", type=float, default=10, help="lupton Q")
+    model_args.add_argument(
+        "--scheme", type=int, default=1, help="classification scheme"
+    )
+    model_args.add_argument("--stretch", type=float, default=0.5, help="lupton stretch")
+    model_args.add_argument(
+        "--tl", type=int, default=1, help="total size of training set"
+    )
+
+    # Add a section of advanced arguments.
+    adv_args = parser.add_argument_group("Advanced arguments")
+
+    # PyTorch still may leave orphan processes in multi-gpu training.
+    # Therefore we use a deterministic way to obtain port,
+    # so that users are aware of orphan processes by seeing the port occupied.
+    port = (
+        2**15
+        + 2**14
+        + hash(os.getuid() if sys.platform != "win32" else 1) % 2**14
+    )
+    adv_args.add_argument(
+        "--dist-url",
+        default="tcp://127.0.0.1:{}".format(port),
+        help="initialization URL for pytorch distributed backend. See "
+        "https://pytorch.org/docs/stable/distributed.html for details.",
+    )
+    adv_args.add_argument(
+        "opts",
+        help="""
+Modify config options at the end of the command. For Yacs configs, use
+space-separated "PATH.KEY VALUE" pairs.
+For python-based LazyConfig, use "path.key=value".
+        """.strip(),
+        default=None,
+        nargs=argparse.REMAINDER,
+    )
+
+    return parser

--- a/test_run_transformers.py
+++ b/test_run_transformers.py
@@ -19,7 +19,6 @@ from detectron2.utils.logger import setup_logger
 
 setup_logger()
 
-import argparse
 import copy
 import gc
 import json
@@ -78,6 +77,7 @@ from deepdisc.model.models import return_lazy_model
 from deepdisc.model.trainers import (return_evallosshook, return_lazy_trainer,
                                      return_optimizer, return_savehook,
                                      return_schedulerhook)
+from deepdisc.utils.parse_arguments import make_training_arg_parser
 
 
 def main(train_head,args):
@@ -210,83 +210,8 @@ def main(train_head,args):
             np.save(output_dir+output_name+'_val_losses',trainer.vallossList)
         return
 
-def custom_argument_parser(epilog=None):
-    """
-    Create a parser with some common arguments used by detectron2 users.
-    Args:
-        epilog (str): epilog passed to ArgumentParser describing the usage.
-    Returns:
-        argparse.ArgumentParser:
-    """
-    parser = argparse.ArgumentParser(
-        epilog=epilog
-        or f"""
-Examples:
-Run on single machine:
-    $ {sys.argv[0]} --num-gpus 8 --config-file cfg.yaml
-Change some config options:
-    $ {sys.argv[0]} --config-file cfg.yaml MODEL.WEIGHTS /path/to/weight.pth SOLVER.BASE_LR 0.001
-Run on multiple machines:
-    (machine0)$ {sys.argv[0]} --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
-    (machine1)$ {sys.argv[0]} --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
-""",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument("--config-file", default="", metavar="FILE", help="path to config file")
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Whether to attempt to resume from the checkpoint directory. "
-        "See documentation of `DefaultTrainer.resume_or_load()` for what it means.",
-    )
-    parser.add_argument("--eval-only", action="store_true", help="perform evaluation only")
-    parser.add_argument("--num-gpus", type=int, default=1, help="number of gpus *per machine*")
-    parser.add_argument("--num-machines", type=int, default=1, help="total number of machines")
-    parser.add_argument("--run-name", type=str, default='Swin_test', help="output name for run")
-    parser.add_argument("--cfgfile", type=str, default='COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml', help="path to model config file")
-    parser.add_argument("--norm", type=str, default='astrolupton', help="contrast scaling")
-    parser.add_argument("--data-dir", type=str, default='/home/shared/hsc/HSC/HSC_DR3/data/', help="directory with data")
-    parser.add_argument("--output-dir", type=str, default='./', help="output directory to save model")
-    parser.add_argument(
-        "--machine-rank", type=int, default=0, help="the rank of this machine (unique per machine)"
-    )
-    parser.add_argument("--cp", type=float, default=99.99, help="ceiling percentile for saturation cutoff")
-    parser.add_argument("--scheme", type=int, default=1, help="classification scheme")
-    parser.add_argument("--alphas", type=float, nargs='*', help="weights for focal loss")
-    parser.add_argument("--modname", type=str, default='swin', help="")
-    parser.add_argument("--stretch", type=float, default=0.5, help="lupton stretch")
-    parser.add_argument("--Q", type=float, default=10, help="lupton Q")
-    parser.add_argument("--A", type=float, default=1e3, help="scaling factor for int16")
-    parser.add_argument("--do-norm", action="store_true", help="normalize input image (ignore if lupton)")
-    parser.add_argument("--dtype", type=int, default=8, help="data type of array")
-    parser.add_argument("--tl", type=int, default=1, help="total size of training set")
-
-    
-    # PyTorch still may leave orphan processes in multi-gpu training.
-    # Therefore we use a deterministic way to obtain port,
-    # so that users are aware of orphan processes by seeing the port occupied.
-    port = 2**15 + 2**14 + hash(os.getuid() if sys.platform != "win32" else 1) % 2**14
-    parser.add_argument(
-        "--dist-url",
-        default="tcp://127.0.0.1:{}".format(port),
-        help="initialization URL for pytorch distributed backend. See "
-        "https://pytorch.org/docs/stable/distributed.html for details.",
-    )
-    parser.add_argument(
-        "opts",
-        help="""
-Modify config options at the end of the command. For Yacs configs, use
-space-separated "PATH.KEY VALUE" pairs.
-For python-based LazyConfig, use "path.key=value".
-        """.strip(),
-        default=None,
-        nargs=argparse.REMAINDER,
-    )
-    return parser
-
-
 if __name__ == "__main__":
-    args = custom_argument_parser().parse_args()
+    args = make_training_arg_parser().parse_args()
     print("Command Line Args:", args)
     
     print('Training head layers')

--- a/train_decam.py
+++ b/train_decam.py
@@ -62,6 +62,7 @@ from detectron2.structures import BoxMode
 from astropy.io import fits
 import glob
 
+from deepdisc.utils.parse_arguments import make_training_arg_parser
 
 def get_data_from_json(file):
     # Opening JSON file
@@ -233,80 +234,8 @@ def main(dataset_names, train_head, args):
         return
 
 
-def custom_argument_parser(epilog=None):
-    """
-    Create a parser with some common arguments used by detectron2 users.
-    Args:
-        epilog (str): epilog passed to ArgumentParser describing the usage.
-    Returns:
-        argparse.ArgumentParser:
-    """
-    parser = argparse.ArgumentParser(
-        epilog=epilog
-        or f"""
-Examples:
-Run on single machine:
-    $ {sys.argv[0]} --num-gpus 8 --config-file cfg.yaml
-Change some config options:
-    $ {sys.argv[0]} --config-file cfg.yaml MODEL.WEIGHTS /path/to/weight.pth SOLVER.BASE_LR 0.001
-Run on multiple machines:
-    (machine0)$ {sys.argv[0]} --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
-    (machine1)$ {sys.argv[0]} --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
-""",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument("--config-file", default="", metavar="FILE", help="path to config file")
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Whether to attempt to resume from the checkpoint directory. "
-        "See documentation of `DefaultTrainer.resume_or_load()` for what it means.",
-    )
-    parser.add_argument("--eval-only", action="store_true", help="perform evaluation only")
-    parser.add_argument("--num-gpus", type=int, default=1, help="number of gpus *per machine*")
-    parser.add_argument("--num-machines", type=int, default=1, help="total number of machines")
-    parser.add_argument("--run-name", type=str, default="baseline", help="output name for run")
-    parser.add_argument(
-        "--cfgfile",
-        type=str,
-        default="COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml",
-        help="path to model config file",
-    )
-    parser.add_argument("--norm", type=str, default="lupton", help="contrast scaling")
-    parser.add_argument(
-        "--data-dir", type=str, default="/home/shared/hsc/decam/decam_data/", help="directory with data"
-    )
-    parser.add_argument("--output-dir", type=str, default="./", help="output directory to save model")
-    parser.add_argument(
-        "--machine-rank", type=int, default=0, help="the rank of this machine (unique per machine)"
-    )
-    parser.add_argument("--cp", type=float, default=99.99, help="ceiling percentile for saturation cutoff")
-
-    # PyTorch still may leave orphan processes in multi-gpu training.
-    # Therefore we use a deterministic way to obtain port,
-    # so that users are aware of orphan processes by seeing the port occupied.
-    port = 2**15 + 2**14 + hash(os.getuid() if sys.platform != "win32" else 1) % 2**14
-    parser.add_argument(
-        "--dist-url",
-        default="tcp://127.0.0.1:{}".format(port),
-        help="initialization URL for pytorch distributed backend. See "
-        "https://pytorch.org/docs/stable/distributed.html for details.",
-    )
-    parser.add_argument(
-        "opts",
-        help="""
-Modify config options at the end of the command. For Yacs configs, use
-space-separated "PATH.KEY VALUE" pairs.
-For python-based LazyConfig, use "path.key=value".
-        """.strip(),
-        default=None,
-        nargs=argparse.REMAINDER,
-    )
-    return parser
-
-
 if __name__ == "__main__":
-    args = custom_argument_parser().parse_args()
+    args = make_training_arg_parser().parse_args()
     print("Command Line Args:", args)
 
     dataset_names = ["train", "test", "val"]

--- a/train_decam_testmodel.py
+++ b/train_decam_testmodel.py
@@ -10,7 +10,6 @@ setup_logger()
 # import some common libraries
 import numpy as np
 import os, json, cv2, random
-import argparse
 import logging
 import sys
 
@@ -68,6 +67,8 @@ from detectron2.data import MetadataCatalog
 import gc
 
 import warnings
+
+from deepdisc.utils.parse_arguments import make_training_arg_parser
 
 # Get a user warning about some upsampling parameter, just ignoring
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -406,88 +407,8 @@ def main(dataset_names, train_head, args):
         return
 
 
-def custom_argument_parser(epilog=None):
-    """
-    Create a parser with some common arguments used by detectron2 users.
-    Args:
-        epilog (str): epilog passed to ArgumentParser describing the usage.
-    Returns:
-        argparse.ArgumentParser:
-    """
-    parser = argparse.ArgumentParser(
-        epilog=epilog
-        or f"""
-Examples:
-Run on single machine:
-    $ {sys.argv[0]} --num-gpus 8 --config-file cfg.yaml
-Change some config options:
-    $ {sys.argv[0]} --config-file cfg.yaml MODEL.WEIGHTS /path/to/weight.pth SOLVER.BASE_LR 0.001
-Run on multiple machines:
-    (machine0)$ {sys.argv[0]} --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
-    (machine1)$ {sys.argv[0]} --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
-""",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument("--config-file", default="", metavar="FILE", help="path to config file")
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Whether to attempt to resume from the checkpoint directory. "
-        "See documentation of `DefaultTrainer.resume_or_load()` for what it means.",
-    )
-    parser.add_argument("--eval-only", action="store_true", help="perform evaluation only")
-    parser.add_argument("--num-gpus", type=int, default=1, help="number of gpus *per machine*")
-    parser.add_argument("--num-machines", type=int, default=1, help="total number of machines")
-    parser.add_argument("--run-name", type=str, default="baseline", help="output name for run")
-    parser.add_argument(
-        "--cfgfile",
-        type=str,
-        default="COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml",
-        help="path to model config file",
-    )
-    parser.add_argument("--norm", type=str, default="lupton", help="contrast scaling")
-    parser.add_argument(
-        "--data-dir", type=str, default="/home/shared/hsc/decam/decam_data/", help="directory with data"
-    )
-    parser.add_argument("--output-dir", type=str, default="./", help="output directory to save model")
-    parser.add_argument(
-        "--machine-rank", type=int, default=0, help="the rank of this machine (unique per machine)"
-    )
-    parser.add_argument("--cp", type=float, default=99.99, help="ceiling percentile for saturation cutoff")
-    parser.add_argument("--scheme", type=int, default=1, help="classification scheme")
-    parser.add_argument("--alphas", type=float, nargs="*", help="weights for focal loss")
-    parser.add_argument("--modname", type=str, default="./", help="")
-    parser.add_argument("--stretch", type=float, default=0.5, help="lupton stretch")
-    parser.add_argument("--Q", type=float, default=10, help="lupton Q")
-    parser.add_argument("--A", type=float, default=1e3, help="scaling factor for int16")
-    parser.add_argument("--do-norm", action="store_true", help="normalize input image (ignore if lupton)")
-    parser.add_argument("--dtype", type=int, default=8, help="data type of array")
-    parser.add_argument("--do-fl", action="store_true", help="use focal loss")
-    # PyTorch still may leave orphan processes in multi-gpu training.
-    # Therefore we use a deterministic way to obtain port,
-    # so that users are aware of orphan processes by seeing the port occupied.
-    port = 2**15 + 2**14 + hash(os.getuid() if sys.platform != "win32" else 1) % 2**14
-    parser.add_argument(
-        "--dist-url",
-        default="tcp://127.0.0.1:{}".format(port),
-        help="initialization URL for pytorch distributed backend. See "
-        "https://pytorch.org/docs/stable/distributed.html for details.",
-    )
-    parser.add_argument(
-        "opts",
-        help="""
-Modify config options at the end of the command. For Yacs configs, use
-space-separated "PATH.KEY VALUE" pairs.
-For python-based LazyConfig, use "path.key=value".
-        """.strip(),
-        default=None,
-        nargs=argparse.REMAINDER,
-    )
-    return parser
-
-
 if __name__ == "__main__":
-    args = custom_argument_parser().parse_args()
+    args = make_training_arg_parser().parse_args()
     print("Command Line Args:", args)
 
     dataset_names = ["train", "test", "val"]

--- a/train_hsc_primary.py
+++ b/train_hsc_primary.py
@@ -84,6 +84,7 @@ from astrodet.detectron import _transform_to_aug
 
 from PIL import Image, ImageEnhance
 
+from deepdisc.utils.parse_arguments import make_training_arg_parser
 
 def get_data_from_json(file):
     # Opening JSON file
@@ -482,96 +483,13 @@ def main(tl, train_head, args):
         return
 
 
-def custom_argument_parser(epilog=None):
-    """
-    Create a parser with some common arguments used by detectron2 users.
-    Args:
-        epilog (str): epilog passed to ArgumentParser describing the usage.
-    Returns:
-        argparse.ArgumentParser:
-    """
-    parser = argparse.ArgumentParser(
-        epilog=epilog
-        or f"""
-Examples:
-Run on single machine:
-    $ {sys.argv[0]} --num-gpus 8 --config-file cfg.yaml
-Change some config options:
-    $ {sys.argv[0]} --config-file cfg.yaml MODEL.WEIGHTS /path/to/weight.pth SOLVER.BASE_LR 0.001
-Run on multiple machines:
-    (machine0)$ {sys.argv[0]} --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
-    (machine1)$ {sys.argv[0]} --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
-""",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument("--config-file", default="", metavar="FILE", help="path to config file")
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Whether to attempt to resume from the checkpoint directory. "
-        "See documentation of `DefaultTrainer.resume_or_load()` for what it means.",
-    )
-    parser.add_argument("--eval-only", action="store_true", help="perform evaluation only")
-    parser.add_argument("--num-gpus", type=int, default=1, help="number of gpus *per machine*")
-    parser.add_argument("--num-machines", type=int, default=1, help="total number of machines")
-    parser.add_argument("--run-name", type=str, default="baseline", help="output name for run")
-    parser.add_argument(
-        "--cfgfile",
-        type=str,
-        default="COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml",
-        help="path to model config file",
-    )
-    parser.add_argument("--norm", type=str, default="lupton", help="contrast scaling")
-    parser.add_argument(
-        "--data-dir", type=str, default="/home/shared/hsc/HSC/HSC_DR3/data/", help="directory with data"
-    )
-    parser.add_argument("--output-dir", type=str, default="./", help="output directory to save model")
-    parser.add_argument(
-        "--machine-rank", type=int, default=0, help="the rank of this machine (unique per machine)"
-    )
-    parser.add_argument("--cp", type=float, default=99.99, help="ceiling percentile for saturation cutoff")
-    parser.add_argument("--scheme", type=int, default=1, help="classification scheme")
-    parser.add_argument("--stretch", type=float, default=0.5, help="lupton stretch")
-    parser.add_argument("--Q", type=float, default=10, help="lupton Q")
-    parser.add_argument("--A", type=float, default=1e3, help="scaling factor for int16")
-    parser.add_argument("--do-norm", action="store_true", help="normalize input image (ignore if lupton)")
-    parser.add_argument("--dtype", type=int, default=8, help="data type of array")
-    parser.add_argument("--do-fl", action="store_true", help="use focal loss")
-    parser.add_argument("--alphas", type=float, nargs="*", help="weights for focal loss")
-    parser.add_argument(
-        "--from-scratch", action="store_true", help="use this if you don't want to use pretrained weights"
-    )
-
-    # PyTorch still may leave orphan processes in multi-gpu training.
-    # Therefore we use a deterministic way to obtain port,
-    # so that users are aware of orphan processes by seeing the port occupied.
-    port = 2**15 + 2**14 + hash(os.getuid() if sys.platform != "win32" else 1) % 2**14
-    parser.add_argument(
-        "--dist-url",
-        default="tcp://127.0.0.1:{}".format(port),
-        help="initialization URL for pytorch distributed backend. See "
-        "https://pytorch.org/docs/stable/distributed.html for details.",
-    )
-    parser.add_argument(
-        "opts",
-        help="""
-Modify config options at the end of the command. For Yacs configs, use
-space-separated "PATH.KEY VALUE" pairs.
-For python-based LazyConfig, use "path.key=value".
-        """.strip(),
-        default=None,
-        nargs=argparse.REMAINDER,
-    )
-    return parser
-
 
 if __name__ == "__main__":
     """
     Runs the training of the head layers for 15 epochs
     then runs the training of the full model for an additional 35 epochs
     """
-
-    args = custom_argument_parser().parse_args()
+    args = make_training_arg_parser().parse_args()
     print("Command Line Args:", args)
 
     dirpath = "/home/shared/hsc/HSC/HSC_DR3/data/"  # Path to dataset

--- a/train_hsc_primary_transformers.py
+++ b/train_hsc_primary_transformers.py
@@ -24,7 +24,6 @@ import numpy as np
 import os, json, cv2, random
 
 # os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:150"
-import argparse
 import logging
 import sys
 import gc
@@ -92,6 +91,7 @@ from detectron2.solver import build_lr_scheduler
 from astropy.visualization import make_lupton_rgb
 from PIL import Image, ImageEnhance
 
+from deepdisc.utils.parse_arguments import make_training_arg_parser
 
 class LazyAstroTrainer(SimpleTrainer):
     def __init__(self, model, data_loader, optimizer, cfg, cfg_old):
@@ -639,89 +639,8 @@ def main(tl, dataset_names, train_head, args):
         return
 
 
-def custom_argument_parser(epilog=None):
-    """
-    Create a parser with some common arguments used by detectron2 users.
-    Args:
-        epilog (str): epilog passed to ArgumentParser describing the usage.
-    Returns:
-        argparse.ArgumentParser:
-    """
-    parser = argparse.ArgumentParser(
-        epilog=epilog
-        or f"""
-Examples:
-Run on single machine:
-    $ {sys.argv[0]} --num-gpus 8 --config-file cfg.yaml
-Change some config options:
-    $ {sys.argv[0]} --config-file cfg.yaml MODEL.WEIGHTS /path/to/weight.pth SOLVER.BASE_LR 0.001
-Run on multiple machines:
-    (machine0)$ {sys.argv[0]} --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
-    (machine1)$ {sys.argv[0]} --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
-""",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument("--config-file", default="", metavar="FILE", help="path to config file")
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Whether to attempt to resume from the checkpoint directory. "
-        "See documentation of `DefaultTrainer.resume_or_load()` for what it means.",
-    )
-    parser.add_argument("--eval-only", action="store_true", help="perform evaluation only")
-    parser.add_argument("--num-gpus", type=int, default=1, help="number of gpus *per machine*")
-    parser.add_argument("--num-machines", type=int, default=1, help="total number of machines")
-    parser.add_argument("--run-name", type=str, default="baseline", help="output name for run")
-    parser.add_argument(
-        "--cfgfile",
-        type=str,
-        default="COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml",
-        help="path to model config file",
-    )
-    parser.add_argument("--norm", type=str, default="lupton", help="contrast scaling")
-    parser.add_argument(
-        "--data-dir", type=str, default="/home/shared/hsc/HSC/HSC_DR3/data/", help="directory with data"
-    )
-    parser.add_argument("--output-dir", type=str, default="./", help="output directory to save model")
-    parser.add_argument(
-        "--machine-rank", type=int, default=0, help="the rank of this machine (unique per machine)"
-    )
-    parser.add_argument("--cp", type=float, default=99.99, help="ceiling percentile for saturation cutoff")
-    parser.add_argument("--scheme", type=int, default=1, help="classification scheme")
-    parser.add_argument("--alphas", type=float, nargs="*", help="weights for focal loss")
-    parser.add_argument("--modname", type=str, default="./", help="")
-    parser.add_argument("--stretch", type=float, default=0.5, help="lupton stretch")
-    parser.add_argument("--Q", type=float, default=10, help="lupton Q")
-    parser.add_argument("--A", type=float, default=1e3, help="scaling factor for int16")
-    parser.add_argument("--do-norm", action="store_true", help="normalize input image (ignore if lupton)")
-    parser.add_argument("--dtype", type=int, default=8, help="data type of array")
-    parser.add_argument("--do-fl", action="store_true", help="use focal loss")
-
-    # PyTorch still may leave orphan processes in multi-gpu training.
-    # Therefore we use a deterministic way to obtain port,
-    # so that users are aware of orphan processes by seeing the port occupied.
-    port = 2**15 + 2**14 + hash(os.getuid() if sys.platform != "win32" else 1) % 2**14
-    parser.add_argument(
-        "--dist-url",
-        default="tcp://127.0.0.1:{}".format(port),
-        help="initialization URL for pytorch distributed backend. See "
-        "https://pytorch.org/docs/stable/distributed.html for details.",
-    )
-    parser.add_argument(
-        "opts",
-        help="""
-Modify config options at the end of the command. For Yacs configs, use
-space-separated "PATH.KEY VALUE" pairs.
-For python-based LazyConfig, use "path.key=value".
-        """.strip(),
-        default=None,
-        nargs=argparse.REMAINDER,
-    )
-    return parser
-
-
 if __name__ == "__main__":
-    args = custom_argument_parser().parse_args()
+    args = make_training_arg_parser().parse_args()
     print("Command Line Args:", args)
 
     dirpath = "/home/shared/hsc/HSC/HSC_DR3/data/"  # Path to dataset


### PR DESCRIPTION
This PR will likely require some discussion as it changes behavior of the training scripts. 

Previously each training used its own `custom_argument_parser` function to provide command line options. This creates a single training parser with the union of the individual options. It also breaks the arguments into sections for readability when `--help` is used.

However the change is that each training script was using different defaults for at least a few parameters. This would standardize the defaults. Is that what we want?