### PR TITLE
Remove unneeded json imports

### DIFF
--- a/test_run_transformers.py
+++ b/test_run_transformers.py
@@ -21,7 +21,6 @@ setup_logger()
 
 import copy
 import gc
-import json
 import logging
 import os
 import random
@@ -73,7 +72,6 @@ from detectron2.engine.defaults import create_ddp_model
 from detectron2.solver import build_lr_scheduler
 from detectron2.structures import BoxMode
 
-from deepdisc.data_format.file_io import get_data_from_json
 from deepdisc.data_format.register_data import register_data_set
 from deepdisc.model.loaders import return_test_loader, return_train_loader
 from deepdisc.model.models import return_lazy_model
@@ -100,18 +98,16 @@ def main(train_head, args):
     alphas = args.alphas
     modname = args.modname
     if modname == "swin":
-        cfgfile = (
-            "./tests/deepdisc/test_data/configs/COCO/cascade_mask_rcnn_swin_b_in21k_50ep.py"
-        )
-        #initwfile = "/home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl"
+        cfgfile = "./tests/deepdisc/test_data/configs/COCO/cascade_mask_rcnn_swin_b_in21k_50ep.py"
+        # initwfile = "/home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl"
     elif modname == "mvitv2":
         cfgfile = "/home/shared/hsc/detectron2/projects/ViTDet/configs/COCO/cascade_mask_rcnn_mvitv2_b_in21k_100ep.py"
-        #initwfile = "/home/shared/hsc/detectron2/projects/ViTDet/model_final_8c3da3.pkl"
+        # initwfile = "/home/shared/hsc/detectron2/projects/ViTDet/model_final_8c3da3.pkl"
 
     elif modname == "vitdet":
         cfgfile = "/home/shared/hsc/detectron2/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_b_100ep.py"
         # initwfile = '/home/g4merz/deblend/detectron2/projects/ViTDet/model_final_435fa9.pkl'
-        #initwfile = "/home/shared/hsc/detectron2/projects/ViTDet/model_final_61ccd1.pkl"
+        # initwfile = "/home/shared/hsc/detectron2/projects/ViTDet/model_final_61ccd1.pkl"
 
     datatype = args.dtype
     if datatype == 8:

--- a/train_decam.py
+++ b/train_decam.py
@@ -9,7 +9,6 @@ setup_logger()
 
 import argparse
 import copy
-import json
 import logging
 import os
 import random
@@ -63,13 +62,6 @@ from detectron2.structures import BoxMode
 
 from deepdisc.data_format.register_data import register_data_set
 from deepdisc.utils.parse_arguments import make_training_arg_parser
-
-
-def get_data_from_json(file):
-    # Opening JSON file
-    with open(file, "r") as f:
-        data = json.load(f)
-    return data
 
 
 def main(dataset_names, train_head, args):

--- a/train_decam_testmodel.py
+++ b/train_decam_testmodel.py
@@ -8,7 +8,6 @@ from detectron2.utils.logger import setup_logger
 setup_logger()
 
 import copy
-import json
 import logging
 import os
 import random
@@ -78,13 +77,6 @@ from deepdisc.utils.parse_arguments import make_training_arg_parser
 
 # Get a user warning about some upsampling parameter, just ignoring
 warnings.filterwarnings("ignore", category=UserWarning)
-
-
-def get_data_from_json(file):
-    # Opening JSON file
-    with open(file, "r") as f:
-        data = json.load(f)
-    return data
 
 
 from detectron2.solver import build_lr_scheduler

--- a/train_hsc_primary.py
+++ b/train_hsc_primary.py
@@ -22,7 +22,6 @@ setup_logger()
 import argparse
 import copy
 import gc
-import json
 import logging
 import os
 import random
@@ -84,15 +83,9 @@ from PIL import Image, ImageEnhance
 
 from astrodet.detectron import _transform_to_aug
 
+from deepdisc.data_format.file_io import get_data_from_json
 from deepdisc.data_format.register_data import register_data_set
 from deepdisc.utils.parse_arguments import make_training_arg_parser
-
-
-def get_data_from_json(file):
-    # Opening JSON file
-    with open(file, "r") as f:
-        data = json.load(f)
-    return data
 
 
 # ### Augment Data

--- a/train_hsc_primary_transformers.py
+++ b/train_hsc_primary_transformers.py
@@ -22,7 +22,6 @@ setup_logger()
 
 import copy
 import gc
-import json
 
 # os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:150"
 import logging
@@ -90,6 +89,7 @@ from PIL import Image, ImageEnhance
 
 from astrodet.detectron import _transform_to_aug
 
+from deepdisc.data_format.file_io import get_data_from_json
 from deepdisc.data_format.register_data import register_data_set
 from deepdisc.utils.parse_arguments import make_training_arg_parser
 
@@ -182,13 +182,6 @@ class LazyAstroTrainer(SimpleTrainer):
         """
 
         self.vallossList.append(val_loss)
-
-
-def get_data_from_json(file):
-    # Opening JSON file
-    with open(file, "r") as f:
-        data = json.load(f)
-    return data
 
 
 # ### Augment Data


### PR DESCRIPTION
Switches all the training scripts to use `deepdisc.data_format.file_io.get_data_from_json()` instead of declaring their own.
Also removes the unneeded `import json`.