### PR TITLE
Add a helper function to get dtype

### DIFF
--- a/src/deepdisc/utils/parse_arguments.py
+++ b/src/deepdisc/utils/parse_arguments.py
@@ -1,6 +1,8 @@
 import argparse
+import numpy as np
 import os
 import sys
+
 
 def make_inference_arg_parser():
     """Create the parser for DeepDisc inference, including common arguments used by
@@ -13,17 +15,18 @@ def make_inference_arg_parser():
     """
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--datatype', default=8, type=int)
-    parser.add_argument('--nc', default=2, type=int)
-    parser.add_argument('--norm', default='astrolupton', type=str, help="contrast scaling")
-    parser.add_argument('--output-dir', default='.', type=str)
-    parser.add_argument('--roi-thresh', default=0.1, type=float)
-    parser.add_argument('--run-name', default='Swin_test.pth', type=str)
-    parser.add_argument('--savedir', default='.', type=str)
-    parser.add_argument('--scheme', default=2, type=int, help="classification scheme")
-    parser.add_argument('--testfile', default='/home/shared/hsc/HSC/HSC_DR3/data/single_test.json', type=str)
+    parser.add_argument("--datatype", default=8, type=int)
+    parser.add_argument("--nc", default=2, type=int)
+    parser.add_argument("--norm", default="astrolupton", type=str, help="contrast scaling")
+    parser.add_argument("--output-dir", default=".", type=str)
+    parser.add_argument("--roi-thresh", default=0.1, type=float)
+    parser.add_argument("--run-name", default="Swin_test.pth", type=str)
+    parser.add_argument("--savedir", default=".", type=str)
+    parser.add_argument("--scheme", default=2, type=int, help="classification scheme")
+    parser.add_argument("--testfile", default="/home/shared/hsc/HSC/HSC_DR3/data/single_test.json", type=str)
 
     return parser
+
 
 def make_training_arg_parser(epilog=None):
     """Create the parser for DeepDisc training, including common arguments used by
@@ -146,3 +149,27 @@ For python-based LazyConfig, use "path.key=value".
     )
 
     return parser
+
+
+def dtype_from_args(dt):
+    """Returns the dtype corresponding to the dtype argument string.
+
+    Parameters
+    ----------
+    dt: int
+        The integer representing the number of bytes to use.
+
+    Returns
+    -------
+    type
+        The dtype to use.
+
+    Raises
+    ------
+    ValueError is the dtype is unrecognized.
+    """
+    if dt == 16:
+        return np.int16
+    elif dt == 8:
+        return np.uint8
+    raise ValueError("Unknown dtype argument {dt}.")

--- a/src/deepdisc/utils/parse_arguments.py
+++ b/src/deepdisc/utils/parse_arguments.py
@@ -151,25 +151,27 @@ For python-based LazyConfig, use "path.key=value".
     return parser
 
 
-def dtype_from_args(dt):
+def dtype_from_args(dt=32):
     """Returns the dtype corresponding to the dtype argument string.
 
     Parameters
     ----------
     dt: int
         The integer representing the number of bytes to use.
+        8 = uint8
+        16 = int16
+        32 = float32 (default)
 
     Returns
     -------
     type
         The dtype to use.
-
-    Raises
-    ------
-    ValueError is the dtype is unrecognized.
     """
-    if dt == 16:
+    if dt == 32:
+        return np.float32
+    elif dt == 16:
         return np.int16
     elif dt == 8:
         return np.uint8
-    raise ValueError("Unknown dtype argument {dt}.")
+    else:
+        raise ValueError("Unknown dtype argument {dt}.")

--- a/test_eval_model.py
+++ b/test_eval_model.py
@@ -68,7 +68,7 @@ from detectron2.structures import BoxMode
 from deepdisc.data_format.file_io import get_data_from_json
 from deepdisc.inference.predictors import return_predictor_transformer
 from deepdisc.inference.match_objects import get_matched_object_classes
-from deepdisc.utils.parse_arguments import make_inference_arg_parser
+from deepdisc.utils.parse_arguments import dtype_from_args, make_inference_arg_parser
 
 '''
 This code will read in a trained model and output the classes for predicted objects matched to the ground truth 
@@ -212,14 +212,7 @@ cfg.train.init_checkpoint = os.path.join(cfg_loader.OUTPUT_DIR, run_name)
 output_dir = args.output_dir
 roi_thresh=args.roi_thresh
 run_name=args.run_name
-dt = args.datatype
-if dt==16:
-    dtype=np.int16
-elif dt==8:
-    dtype = np.uint8
-
-
-    
+dtype=dtype_from_args(args.datatype)
 
 if bb in ['Swin','MViTv2']:
     predictor= return_predictor_transformer(cfg,cfg_loader)

--- a/test_run_transformers.py
+++ b/test_run_transformers.py
@@ -84,7 +84,7 @@ from deepdisc.training.trainers import (
     return_savehook,
     return_schedulerhook,
 )
-from deepdisc.utils.parse_arguments import make_training_arg_parser
+from deepdisc.utils.parse_arguments import dtype_from_args, make_training_arg_parser
 
 
 def main(train_head, args):
@@ -113,12 +113,7 @@ def main(train_head, args):
         # initwfile = '/home/g4merz/deblend/detectron2/projects/ViTDet/model_final_435fa9.pkl'
         #initwfile = "/home/shared/hsc/detectron2/projects/ViTDet/model_final_61ccd1.pkl"
 
-    datatype = args.dtype
-    if datatype == 8:
-        dtype = np.uint8
-    elif datatype == 16:
-        dtype = np.int16
-
+    dtype = dtype_from_args(args.dtype)
     trainfile = dirpath + "single_test.json"
     testfile = dirpath + "single_test.json"
 

--- a/tests/deepdisc/utils/test_parse_arguments.py
+++ b/tests/deepdisc/utils/test_parse_arguments.py
@@ -60,8 +60,10 @@ def test_make_training_arg_parser():
 def test_dtype_from_args():
     assert dtype_from_args(8) is np.uint8
     assert dtype_from_args(16) is np.int16
+    assert dtype_from_args(32) is np.float32
+    assert dtype_from_args() is np.float32
 
     with pytest.raises(ValueError):
         _ = dtype_from_args(4)
     with pytest.raises(ValueError):
-        _ = dtype_from_args(32)  # Do we want to support this too?
+        _ = dtype_from_args(64)

--- a/tests/deepdisc/utils/test_parse_arguments.py
+++ b/tests/deepdisc/utils/test_parse_arguments.py
@@ -1,7 +1,12 @@
 import argparse
+import numpy as np
 import pytest
 
-from deepdisc.utils.parse_arguments import make_inference_arg_parser, make_training_arg_parser
+from deepdisc.utils.parse_arguments import (
+    dtype_from_args,
+    make_inference_arg_parser,
+    make_training_arg_parser,
+)
 
 
 def test_make_inference_arg_parser():
@@ -50,3 +55,13 @@ def test_make_training_arg_parser():
     assert args.scheme == 1
     assert args.stretch == 0.5
     assert args.tl == 1
+
+
+def test_dtype_from_args():
+    assert dtype_from_args(8) is np.uint8
+    assert dtype_from_args(16) is np.int16
+
+    with pytest.raises(ValueError):
+        _ = dtype_from_args(4)
+    with pytest.raises(ValueError):
+        _ = dtype_from_args(32)  # Do we want to support this too?

--- a/train_decam_testmodel.py
+++ b/train_decam_testmodel.py
@@ -74,7 +74,7 @@ from detectron2.engine.defaults import create_ddp_model
 from detectron2.structures import BoxMode
 
 from deepdisc.data_format.register_data import register_data_set
-from deepdisc.utils.parse_arguments import make_training_arg_parser
+from deepdisc.utils.parse_arguments import dtype_from_args, make_training_arg_parser
 
 # Get a user warning about some upsampling parameter, just ignoring
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -190,11 +190,7 @@ def main(dataset_names, train_head, args):
     output_name = args.run_name
     cfgfile = args.cfgfile
     dirpath = args.data_dir  # Path to dataset
-    datatype = args.dtype
-    if datatype == 8:
-        dtype = np.uint8
-    elif datatype == 16:
-        dtype = np.int16
+    dtype = dtype_from_args(args.dtype)
 
     modname = args.modname
     if modname == "swin":

--- a/train_hsc_primary.py
+++ b/train_hsc_primary.py
@@ -85,7 +85,7 @@ from PIL import Image, ImageEnhance
 from astrodet.detectron import _transform_to_aug
 
 from deepdisc.data_format.register_data import register_data_set
-from deepdisc.utils.parse_arguments import make_training_arg_parser
+from deepdisc.utils.parse_arguments import dtype_from_args, make_training_arg_parser
 
 
 def get_data_from_json(file):
@@ -279,11 +279,8 @@ def main(tl, train_head, args):
     dirpath = args.data_dir  # Path to dataset
     scheme = args.scheme
     alphas = args.alphas
-    datatype = args.dtype
-    if datatype == 8:
-        dtype = np.uint8
-    elif datatype == 16:
-        dtype = np.int16
+    dtype = dtype_from_args(args.dtype)
+
     # ### Prepare For Training
     # Training logic:
     # To replicate 2019 methodology, need to

--- a/train_hsc_primary_transformers.py
+++ b/train_hsc_primary_transformers.py
@@ -91,7 +91,7 @@ from PIL import Image, ImageEnhance
 from astrodet.detectron import _transform_to_aug
 
 from deepdisc.data_format.register_data import register_data_set
-from deepdisc.utils.parse_arguments import make_training_arg_parser
+from deepdisc.utils.parse_arguments import dtype_from_args, make_training_arg_parser
 
 
 class LazyAstroTrainer(SimpleTrainer):
@@ -393,11 +393,7 @@ def main(tl, dataset_names, train_head, args):
         # initwfile = '/home/g4merz/deblend/detectron2/projects/ViTDet/model_final_435fa9.pkl'
         initwfile = "/home/g4merz/detectron2/projects/ViTDet/model_final_61ccd1.pkl"
 
-    datatype = args.dtype
-    if datatype == 8:
-        dtype = np.uint8
-    elif datatype == 16:
-        dtype = np.int16
+    dtype = dtype_from_args(args.dtype)
 
     # ### Prepare For Training
     # Training logic:


### PR DESCRIPTION
Add a simple helper function to `parse_arguments.py` to extract the dtype (and do basic error checking). Replaces the conditionals throughout the test scripts.