### PR TITLE
Fix broken argument parser test

### DIFF
--- a/tests/deepdisc/utils/test_parse_arguments.py
+++ b/tests/deepdisc/utils/test_parse_arguments.py
@@ -11,7 +11,7 @@ from deepdisc.utils.parse_arguments import (
 
 def test_make_inference_arg_parser():
     parser = make_inference_arg_parser()
-    args = parser.parse_args()
+    args = parser.parse_known_args()[0]
 
     # Check all parameters are included and the default values are expected.
     assert args.datatype == 8
@@ -27,7 +27,7 @@ def test_make_inference_arg_parser():
 
 def test_make_training_arg_parser():
     parser = make_training_arg_parser()
-    args = parser.parse_args()
+    args = parser.parse_known_args()[0]
 
     # Check all parameters are included and the default values are expected.
     assert type(args.cfgfile) is str and len(args.cfgfile) > 0

--- a/tests/deepdisc/utils/test_parse_arguments.py
+++ b/tests/deepdisc/utils/test_parse_arguments.py
@@ -11,7 +11,7 @@ from deepdisc.utils.parse_arguments import (
 
 def test_make_inference_arg_parser():
     parser = make_inference_arg_parser()
-    args = parser.parse_known_args()[0]
+    args = parser.parse_args([])
 
     # Check all parameters are included and the default values are expected.
     assert args.datatype == 8
@@ -27,7 +27,7 @@ def test_make_inference_arg_parser():
 
 def test_make_training_arg_parser():
     parser = make_training_arg_parser()
-    args = parser.parse_known_args()[0]
+    args = parser.parse_args([])
 
     # Check all parameters are included and the default values are expected.
     assert type(args.cfgfile) is str and len(args.cfgfile) > 0


### PR DESCRIPTION
Use `parse_known_args` instead of `parse_args` so the coverage tests do not fail. `parse_known_args` returns a tuple of (known, unknown) args, so we take the first element of that tuple.