### PR TITLE
Move the key_mapper functionality into ImageReader

### DIFF
--- a/src/deepdisc/inference/match_objects.py
+++ b/src/deepdisc/inference/match_objects.py
@@ -50,13 +50,13 @@ def get_matched_object_inds(dataset_dict, outputs):
     return matched_gts, matched_dts
 
 
-def get_matched_object_classes(dataset_dicts, imreader, key_mapper, predictor):
+def get_matched_object_classes(dataset_dicts, imreader, predictor):
     IOUthresh = 0.5
 
     # going to assume we only have one test image right now
 
     for d in dataset_dicts:
-        outputs = get_predictions(d, imreader, key_mapper, predictor)
+        outputs = get_predictions(d, imreader, predictor)
         matched_gts, matched_dts = get_matched_object_inds(d, outputs)
     true_classes = []
     pred_classes = []
@@ -69,7 +69,7 @@ def get_matched_object_classes(dataset_dicts, imreader, key_mapper, predictor):
     return true_classes, pred_classes
 
 
-def get_matched_z_pdfs(dataset_dicts, imreader, key_mapper, predictor):
+def get_matched_z_pdfs(dataset_dicts, imreader, predictor):
     IOUthresh = 0.5
     zs = np.linspace(-1, 5.0, 200)
 
@@ -77,7 +77,7 @@ def get_matched_z_pdfs(dataset_dicts, imreader, key_mapper, predictor):
     zpreds = []
 
     for d in dataset_dicts:
-        outputs = get_predictions(d, imreader, key_mapper, predictor)
+        outputs = get_predictions(d, imreader, predictor)
         matched_gts, matched_dts = get_matched_object_inds(d, outputs)
 
         for gti, dti in zip(matched_gts, matched_dts):

--- a/src/deepdisc/inference/predictors.py
+++ b/src/deepdisc/inference/predictors.py
@@ -23,7 +23,7 @@ def return_predictor_transformer(cfg, cfg_loader):
     return predictor
 
 
-def get_predictions(dataset_dict, imreader, key_mapper, predictor):
+def get_predictions(dataset_dict, imreader, predictor):
     """Returns indices for matched pairs of ground truth and detected objects in an image
 
     Parameters
@@ -32,8 +32,6 @@ def get_predictions(dataset_dict, imreader, key_mapper, predictor):
         The dictionary metadata for a single image
     imreader: ImageReader object
         An object derived from ImageReader base class to read the images.
-    key_mapper: function
-        The key_mapper should take a dataset_dict as input and return the key used by imreader
     predictor: AstroPredictor
         The predictor object used to make predictions on the test set
 
@@ -46,8 +44,6 @@ def get_predictions(dataset_dict, imreader, key_mapper, predictor):
         outputs: list(Intances)
             The list of detected object Instances
     """
-
-    key = key_mapper(dataset_dict)
-    img = imreader(key)
+    img = imreader.read(dataset_dict)
     outputs = predictor(img)
     return outputs

--- a/src/deepdisc/model/loaders.py
+++ b/src/deepdisc/model/loaders.py
@@ -11,15 +11,12 @@ import deepdisc.astrodet.detectron as detectron_addons
 
 
 class train_mapper_cls:
-    def __init__(self, imreader, key_mapper):
+    def __init__(self, imreader):
         self.IR = imreader
-        self.km = key_mapper
 
     def __call__(self, dataset_dict):
         dataset_dict = copy.deepcopy(dataset_dict)
-        key = self.km(dataset_dict)
-
-        image = self.IR(key)
+        image = self.IR.read(dataset_dict)
 
         augs = detectron_addons.KRandomAugmentationList(
             [
@@ -56,15 +53,12 @@ class train_mapper_cls:
 
 
 class redshift_train_mapper_cls:
-    def __init__(self, imreader, key_mapper):
+    def __init__(self, imreader):
         self.IR = imreader
-        self.km = key_mapper
 
     def __call__(self, dataset_dict):
         dataset_dict = copy.deepcopy(dataset_dict)
-        key = self.km(dataset_dict)
-
-        image = self.IR(key)
+        image = self.IR.read(dataset_dict)
 
         augs = detectron_addons.KRandomAugmentationList(
             [
@@ -124,15 +118,12 @@ def return_train_loader(cfg_loader, mapper):
 
 
 class test_mapper_cls:
-    def __init__(self, imreader, key_mapper):
+    def __init__(self, imreader):
         self.IR = imreader
-        self.km = key_mapper
 
     def __call__(self, dataset_dict):
         dataset_dict = copy.deepcopy(dataset_dict)
-        key = self.km(dataset_dict)
-
-        image = self.IR(key)
+        image = self.IR.read(dataset_dict)
 
         augs = T.AugmentationList(
             [
@@ -169,15 +160,12 @@ class test_mapper_cls:
 
 
 class redshift_test_mapper_cls:
-    def __init__(self, imreader, key_mapper):
+    def __init__(self, imreader):
         self.IR = imreader
-        self.km = key_mapper
 
     def __call__(self, dataset_dict):
         dataset_dict = copy.deepcopy(dataset_dict)
-        key = self.km(dataset_dict)
-
-        image = self.IR(key)
+        image = self.IR.read(dataset_dict)
 
         augs = T.AugmentationList([])
         # Data Augmentation

--- a/test_eval_model.py
+++ b/test_eval_model.py
@@ -188,16 +188,6 @@ if bb in ['Swin','MViTv2']:
 else:
     predictor, cfg = return_predictor(cfgfile, run_name, output_dir=output_dir, nc=2, roi_thresh=roi_thresh)
 
-
-def hsc_key_mapper(dataset_dict):
-    filenames = [
-        dataset_dict["filename_G"],
-        dataset_dict["filename_R"],
-        dataset_dict["filename_I"],
-    ]
-    return filenames
-
-
 IR = HSCImageReader(norm=args.norm)
 
 
@@ -205,7 +195,7 @@ t0 = time.time()
 
 
 print("Matching objects")
-true_classes, pred_classes = get_matched_object_classes(dataset_dicts["test"], IR, hsc_key_mapper, predictor)
+true_classes, pred_classes = get_matched_object_classes(dataset_dicts["test"], IR, predictor)
 classes = np.array([true_classes, pred_classes])
 
 savename = f"{bb}_test_matched_classes.npy"

--- a/test_eval_model_DC2.py
+++ b/test_eval_model_DC2.py
@@ -198,21 +198,12 @@ if bb in ["Swin", "MViTv2"]:
 else:
     predictor, cfg = return_predictor(cfgfile, run_name, output_dir=output_dir, nc=2, roi_thresh=roi_thresh)
 
-
-def dc2_key_mapper(dataset_dict):
-    filename = dataset_dict["filename"]
-    return filename
-
-
 IR = DC2ImageReader(norm=args.norm)
-
 
 t0 = time.time()
 
-
 print("Matching objects")
-true_classes, pred_classes = get_matched_object_classes(dataset_dicts["test"], IR, dc2_key_mapper, predictor)
-# true_zs, pred_pdfs = get_matched_z_pdfs(dataset_dicts['test'], IR, dc2_key_mapper, predictor)
+true_classes, pred_classes = get_matched_object_classes(dataset_dicts["test"], IR, predictor)
 
 classes = np.array([true_classes, pred_classes])
 

--- a/test_eval_model_DC2_redshift.py
+++ b/test_eval_model_DC2_redshift.py
@@ -20,9 +20,6 @@ from detectron2 import model_zoo
 from detectron2.config import get_cfg
 from detectron2.data import MetadataCatalog
 
-# from astrodet import astrodet as toolkit
-# from astrodet import detectron as detectron_addons
-
 import deepdisc.astrodet.astrodet as toolkit
 
 logger = logging.getLogger(__name__)
@@ -199,19 +196,15 @@ if bb in ["Swin", "MViTv2"]:
 else:
     predictor, cfg = return_predictor(cfgfile, run_name, output_dir=output_dir, nc=2, roi_thresh=roi_thresh)
 
-def dc2_key_mapper(dataset_dict):
-    filename = dataset_dict["filename"]
-    return filename
 
 IR = DC2ImageReader(norm=args.norm)
-
 
 t0 = time.time()
 
 
 print("Matching objects")
-true_classes, pred_classes = get_matched_object_classes(dataset_dicts["test"], IR, dc2_key_mapper, predictor)
-true_zs, pred_pdfs = get_matched_z_pdfs(dataset_dicts["test"], IR, dc2_key_mapper, predictor)
+true_classes, pred_classes = get_matched_object_classes(dataset_dicts["test"], IR, predictor)
+true_zs, pred_pdfs = get_matched_z_pdfs(dataset_dicts["test"], IR, predictor)
 
 print(true_zs, pred_pdfs)
 

--- a/test_run_transformers.py
+++ b/test_run_transformers.py
@@ -144,19 +144,10 @@ def main(train_head, args):
 
         optimizer = return_optimizer(cfg)
 
-        #key_mapper function should take a dataset_dict as input and output a key used by the image_reader function
-        def hsc_key_mapper(dataset_dict):
-            filenames = [
-                dataset_dict["filename_G"],
-                dataset_dict["filename_R"],
-                dataset_dict["filename_I"],
-            ]
-            return filenames
-
         IR = HSCImageReader(norm=args.norm)
-        mapper = train_mapper_cls(IR, hsc_key_mapper)
+        mapper = train_mapper_cls(IR)
         loader = return_train_loader(cfg_loader, mapper)
-        test_mapper = test_mapper_cls(IR, hsc_key_mapper)
+        test_mapper = test_mapper_cls(IR)
         test_loader = return_test_loader(cfg_loader, test_mapper)
 
         saveHook = return_savehook(output_name)

--- a/test_run_transformers_DC2.py
+++ b/test_run_transformers_DC2.py
@@ -52,13 +52,6 @@ from deepdisc.training.trainers import (
 )
 from deepdisc.utils.parse_arguments import make_training_arg_parser
 
-# from astrodet import astrodet as toolkit
-# from astrodet import detectron as detectron_addons
-
-
-
-
-
 
 def main(train_head, args):
     # Hack if you get SSL certificate error
@@ -165,14 +158,10 @@ def main(train_head, args):
 
         optimizer = return_optimizer(cfg)
 
-        def dc2_key_mapper(dataset_dict):
-            filename = dataset_dict["filename"]
-            return filename
-
         IR = DC2ImageReader(norm=args.norm)
-        mapper = redshift_train_mapper_cls(IR, dc2_key_mapper)
+        mapper = redshift_train_mapper_cls(IR)
         loader = return_train_loader(cfg_loader, mapper)
-        test_mapper = redshift_test_mapper_cls(IR, dc2_key_mapper)
+        test_mapper = redshift_test_mapper_cls(IR)
         test_loader = return_test_loader(cfg_loader, test_mapper)
 
         saveHook = return_savehook(output_name)

--- a/test_run_transformers_DC2_redshift.py
+++ b/test_run_transformers_DC2_redshift.py
@@ -165,14 +165,10 @@ def main(train_head, args):
 
         optimizer = return_optimizer(cfg)
 
-        def dc2_key_mapper(dataset_dict):
-            filename = dataset_dict["filename"]
-            return filename
-
         IR = DC2ImageReader(norm=args.norm)
-        mapper = redshift_train_mapper_cls(IR, dc2_key_mapper)
+        mapper = redshift_train_mapper_cls(IR)
         loader = return_train_loader(cfg_loader, mapper)
-        test_mapper = redshift_test_mapper_cls(IR, dc2_key_mapper)
+        test_mapper = redshift_test_mapper_cls(IR)
         test_loader = return_test_loader(cfg_loader, test_mapper)
 
         saveHook = return_savehook(output_name)

--- a/tests/deepdisc/data_format/test_image_readers.py
+++ b/tests/deepdisc/data_format/test_image_readers.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import pytest
 
 from deepdisc.data_format.image_readers import DC2ImageReader, HSCImageReader
@@ -6,16 +7,59 @@ from deepdisc.data_format.image_readers import DC2ImageReader, HSCImageReader
 def test_read_hsc_data(hsc_triple_test_file):
     """Test that we can read the test DC2 data."""
     ir = HSCImageReader(norm="raw")
-    img = ir(hsc_triple_test_file)
+    img = ir.read(hsc_triple_test_file)
     assert img.shape[0] == 1050
     assert img.shape[1] == 1025
     assert img.shape[2] == 3
 
+    # Check we can load from a dictionary as well.
+    config_dict = {
+        "filename_G": hsc_triple_test_file[0],
+        "filename_R": hsc_triple_test_file[1],
+        "filename_I": hsc_triple_test_file[2],    
+    }
+    img2 = ir.read(config_dict)
+    assert img2.shape[0] == 1050
+    assert img2.shape[1] == 1025
+    assert img2.shape[2] == 3
+
+    # Unknown input type.
+    with pytest.raises(TypeError):
+        img3 = ir.read(10.1)
 
 def test_read_dc2_data(dc2_single_test_file):
     """Test that we can read the test DC2 data."""
     ir = DC2ImageReader(norm="raw")
-    img = ir(dc2_single_test_file)
+    img = ir.read(dc2_single_test_file)
     assert img.shape[0] == 525
     assert img.shape[1] == 525
     assert img.shape[2] == 6
+
+    # Check we can load from a dictionary as well.
+    config_dict = { "filename": dc2_single_test_file }
+    img2 = ir.read(config_dict)
+    assert img2.shape[0] == 525
+    assert img2.shape[1] == 525
+    assert img2.shape[2] == 6
+
+    # Unknown input type.
+    with pytest.raises(TypeError):
+        img3 = ir.read(10.1)
+
+def test_read_numpy_data():
+    """Test that we take data from a numpy array."""
+    arr = np.zeros((10, 15, 3))
+
+    # DC2 reader
+    ir = DC2ImageReader(norm="raw")
+    img = ir.read(arr)
+    assert img.shape[0] == 10
+    assert img.shape[1] == 15
+    assert img.shape[2] == 3
+
+    # HSC Reader
+    ir2 = HSCImageReader(norm="raw")
+    img2 = ir2.read(arr)
+    assert img2.shape[0] == 10
+    assert img2.shape[1] == 15
+    assert img2.shape[2] == 3


### PR DESCRIPTION
Moves the `key_mapper` functionality into the `ImageReader` and generalizing so that the image readers can take:
- a configuration dictionary
- a numpy array representing the image
- a list of filenames (HSC only)
- a filename (DC2 only)
We could generalize this a lot more (making the mapper functionality its own class that can be passed in like the `key_mapper` was, adding more formats (including a list of options), providing for more file formats, etc.). For now I am keeping it simple until there are enough formats to know the best way to generalize.