### PR TITLE
Commenting out automatic pylint checks

### DIFF
--- a/.github/linting.yml
+++ b/.github/linting.yml
@@ -1,3 +1,7 @@
+# !!! MOVE THIS FILE BACK TO ./workflows WHEN IT'S TIME TO REINTRODUCE PYLINT !!!
+# While this file is outside of the workflows directory, the workflow it defines
+# will not run automatically.
+
 # This workflow will install Python dependencies, then perform static linting analysis.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,36 +56,36 @@ repos:
 
 
     # Analyze the src code style and report code that doesn't adhere.
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint (python files in src/)
-        entry: pylint
-        language: system
-        types: [python]
-        files: ^src/
-        args:
-          [
-            "-rn", # Only display messages
-            "-sn", # Don't display the score
-            "--rcfile=src/.pylintrc",
-          ]
+  # - repo: local
+  #   hooks:
+  #     - id: pylint
+  #       name: pylint (python files in src/)
+  #       entry: pylint
+  #       language: system
+  #       types: [python]
+  #       files: ^src/
+  #       args:
+  #         [
+  #           "-rn", # Only display messages
+  #           "-sn", # Don't display the score
+  #           "--rcfile=src/.pylintrc",
+  #         ]
 
     # Analyze the tests code style and report code that doesn't adhere.
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint (python files in tests/ and benchmarks/)
-        entry: pylint
-        language: system
-        types: [python]
-        files: ^(tests|benchmarks)/
-        args:
-          [
-            "-rn", # Only display messages
-            "-sn", # Don't display the score
-            "--rcfile=tests/.pylintrc",
-          ]
+  # - repo: local
+  #   hooks:
+  #     - id: pylint
+  #       name: pylint (python files in tests/ and benchmarks/)
+  #       entry: pylint
+  #       language: system
+  #       types: [python]
+  #       files: ^(tests|benchmarks)/
+  #       args:
+  #         [
+  #           "-rn", # Only display messages
+  #           "-sn", # Don't display the score
+  #           "--rcfile=tests/.pylintrc",
+  #         ]
 
 
 


### PR DESCRIPTION
I've commented out the pylint checks, because right now they aren't helping, and we don't currently have time to address the errors being reported. 

I've also moved the `lint.yml` file out of the .github/workflows directory into .github. It won't run automatically, but when we're ready to reintroduce pylint checks, we can simply move it back to the workflows directory, and uncomment the pylint checks in `.pre-commit.yaml`.