### PR TITLE
Add .map_data after DictMappers in test_run_transformers_DC2.py

### DIFF
--- a/test_run_transformers_DC2.py
+++ b/test_run_transformers_DC2.py
@@ -160,9 +160,9 @@ def main(train_head, args):
             return filename
 
         IR = DC2ImageReader(norm=args.norm)
-        mapper = DictMapper(IR, dc2_key_mapper, train_augs)
+        mapper = DictMapper(IR, dc2_key_mapper, train_augs).map_data
         loader = return_train_loader(cfg_loader, mapper)
-        test_mapper = DictMapper(IR, dc2_key_mapper)
+        test_mapper = DictMapper(IR, dc2_key_mapper).map_data
         test_loader = return_test_loader(cfg_loader, test_mapper)
 
         saveHook = return_savehook(output_name)


### PR DESCRIPTION
For #17 

Without the `.map_data`s, running this would give:
```
ERROR [12/05 09:50:52 d2.engine.train_loop]: Exception during training:
Traceback (most recent call last):
  File "/home/olynn/detectron2/detectron2/engine/train_loop.py", line 155, in train
    self.run_step()
  File "/home/olynn/deepdisc/src/deepdisc/training/trainers.py", line 52, in run_step
    data = next(self._data_loader_iter)
  File "/home/olynn/detectron2/detectron2/data/common.py", line 329, in __iter__
    for d in self.dataset:
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 628, in __next__
    data = self._next_data()
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 1333, in _next_data
    return self._process_data(data)
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 1359, in _process_data
    data.reraise()
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/_utils.py", line 543, in reraise
    raise exception
TypeError: Caught TypeError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/_utils/worker.py", line 302, in _worker_loop
    data = fetcher.fetch(index)
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py", line 34, in fetch
    data.append(next(self.dataset_iter))
  File "/home/olynn/detectron2/detectron2/data/common.py", line 296, in __iter__
    yield self.dataset[idx]
  File "/home/olynn/detectron2/detectron2/data/common.py", line 125, in __getitem__
    data = self._map_func(self._dataset[cur_idx])
  File "/home/olynn/detectron2/detectron2/utils/serialize.py", line 26, in __call__
    return self._obj(*args, **kwargs)
TypeError: 'DictMapper' object is not callable

saving Swin_test
Traceback (most recent call last):
  File "/home/olynn/deepdisc/test_run_transformers_DC2.py", line 190, in <module>
    launch(
  File "/home/olynn/detectron2/detectron2/engine/launch.py", line 84, in launch
    main_func(*args)
  File "/home/olynn/deepdisc/test_run_transformers_DC2.py", line 176, in main
    trainer.train(0, 20)
  File "/home/olynn/detectron2/detectron2/engine/train_loop.py", line 155, in train
    self.run_step()
  File "/home/olynn/deepdisc/src/deepdisc/training/trainers.py", line 52, in run_step
    data = next(self._data_loader_iter)
  File "/home/olynn/detectron2/detectron2/data/common.py", line 329, in __iter__
    for d in self.dataset:
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 628, in __next__
    data = self._next_data()
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 1333, in _next_data
    return self._process_data(data)
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/dataloader.py", line 1359, in _process_data
    data.reraise()
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/_utils.py", line 543, in reraise
    raise exception
TypeError: Caught TypeError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/_utils/worker.py", line 302, in _worker_loop
    data = fetcher.fetch(index)
  File "/home/olynn/.conda/envs/ddr/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py", line 34, in fetch
    data.append(next(self.dataset_iter))
  File "/home/olynn/detectron2/detectron2/data/common.py", line 296, in __iter__
    yield self.dataset[idx]
  File "/home/olynn/detectron2/detectron2/data/common.py", line 125, in __getitem__
    data = self._map_func(self._dataset[cur_idx])
  File "/home/olynn/detectron2/detectron2/utils/serialize.py", line 26, in __call__
    return self._obj(*args, **kwargs)
TypeError: 'DictMapper' object is not callable
```
