### PR TITLE
Instantiate AstroPredictor with in-memory model weights

### DIFF
--- a/src/deepdisc/astrodet/astrodet.py
+++ b/src/deepdisc/astrodet/astrodet.py
@@ -255,7 +255,7 @@ class AstroPredictor:
         inputs = cv2.imread("input.jpg")
         outputs = pred(inputs)
     """
-    def __init__(self, cfg, lazy=False, cfglazy=None):
+    def __init__(self, cfg, lazy=False, cfglazy=None, checkpoint=None):
         self.cfg = copy.deepcopy(cfg) # cfg can be modified by model
         
         if "model" in self.cfg: # This is when were using a LazyConfig-style model in the solo config
@@ -271,8 +271,14 @@ class AstroPredictor:
             self.metadata = MetadataCatalog.get(cfg.DATASETS.TEST[0])
 
         checkpointer = DetectionCheckpointer(self.model)
-        checkpointer.load(cfg.MODEL.WEIGHTS)
 
+        # If we provide AstroPredictor with a checkpoint already loaded in memory
+        # just simply load the weights into the model.
+        if checkpoint:
+            checkpointer._load_model(checkpoint)
+        else:
+            checkpointer.load(cfg.train.init_checkpoint)
+        
         self.aug = T.ResizeShortestEdge(
             [cfg.INPUT.MIN_SIZE_TEST, cfg.INPUT.MIN_SIZE_TEST], cfg.INPUT.MAX_SIZE_TEST
         )

--- a/src/deepdisc/inference/predictors.py
+++ b/src/deepdisc/inference/predictors.py
@@ -1,7 +1,7 @@
 import deepdisc.astrodet.astrodet as toolkit
 
 
-def return_predictor_transformer(cfg):
+def return_predictor_transformer(cfg, checkpoint=None):
     """This function returns a trained model and its config file.
     
     Used for models with lazy config files. Also assumes a cascade roi head structure.
@@ -15,7 +15,7 @@ def return_predictor_transformer(cfg):
         torch model
 
     """
-    predictor = toolkit.AstroPredictor(cfg)
+    predictor = toolkit.AstroPredictor(cfg, checkpoint=checkpoint)
     return predictor
 
 


### PR DESCRIPTION
Prior to this change model weights were only loaded from a file. However, to support wrapping with RAIL, we need to be able to accept the actual model weight dictionary directly (from the ceci DataStore). 

This work allows the user to pass either a file path or a model weight dictionary, or rather a `checkpoint`, when initializing AstroPredictor.  